### PR TITLE
feat: add bouncing boubles ts skeleton

### DIFF
--- a/typescript/bouncing-boubles/.gitignore
+++ b/typescript/bouncing-boubles/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/typescript/bouncing-boubles/index.html
+++ b/typescript/bouncing-boubles/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Bouncing Boubles</title>
+<style>
+  canvas { border: 1px solid #000; image-rendering: pixelated; }
+  body { margin: 0; display: flex; justify-content: center; align-items: center; height: 100vh; background: #ddd; }
+</style>
+</head>
+<body>
+<canvas id="game" width="640" height="400"></canvas>
+<script type="module" src="dist/main.js"></script>
+</body>
+</html>

--- a/typescript/bouncing-boubles/package-lock.json
+++ b/typescript/bouncing-boubles/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "bouncing-boubles",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bouncing-boubles",
+      "version": "0.1.0",
+      "devDependencies": {
+        "typescript": "^5.4.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/typescript/bouncing-boubles/package.json
+++ b/typescript/bouncing-boubles/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "bouncing-boubles",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "test": "npm run build"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0"
+  }
+}

--- a/typescript/bouncing-boubles/src/core/input.ts
+++ b/typescript/bouncing-boubles/src/core/input.ts
@@ -1,0 +1,21 @@
+export class Input {
+  left = false;
+  right = false;
+  mouseX = 0;
+
+  constructor(private canvas: HTMLCanvasElement) {
+    window.addEventListener('keydown', (e) => {
+      if (e.key === 'ArrowLeft') this.left = true;
+      if (e.key === 'ArrowRight') this.right = true;
+    });
+    window.addEventListener('keyup', (e) => {
+      if (e.key === 'ArrowLeft') this.left = false;
+      if (e.key === 'ArrowRight') this.right = false;
+    });
+
+    canvas.addEventListener('mousemove', (e) => {
+      const rect = canvas.getBoundingClientRect();
+      this.mouseX = e.clientX - rect.left;
+    });
+  }
+}

--- a/typescript/bouncing-boubles/src/core/loop.ts
+++ b/typescript/bouncing-boubles/src/core/loop.ts
@@ -1,0 +1,30 @@
+export type UpdateFn = (dt: number) => void;
+export type RenderFn = () => void;
+
+/**
+ * Creates a basic fixed timestep loop.
+ * @param update called with a fixed timestep in ms
+ * @param render called once per animation frame after updates
+ * @param timestep desired timestep in ms (default 16.666ms ~60Hz)
+ */
+export function createLoop(update: UpdateFn, render: RenderFn, timestep = 1000 / 60) {
+  let last = 0;
+  let accumulator = 0;
+
+  function frame(time: number) {
+    if (!last) last = time;
+    const delta = time - last;
+    last = time;
+    accumulator += delta;
+
+    while (accumulator >= timestep) {
+      update(timestep);
+      accumulator -= timestep;
+    }
+
+    render();
+    requestAnimationFrame(frame);
+  }
+
+  requestAnimationFrame(frame);
+}

--- a/typescript/bouncing-boubles/src/core/math.ts
+++ b/typescript/bouncing-boubles/src/core/math.ts
@@ -1,0 +1,17 @@
+export interface Vec2 { x: number; y: number; }
+
+export function vec2(x = 0, y = 0): Vec2 {
+  return { x, y };
+}
+
+export function add(a: Vec2, b: Vec2): Vec2 {
+  return { x: a.x + b.x, y: a.y + b.y };
+}
+
+export function scale(v: Vec2, s: number): Vec2 {
+  return { x: v.x * s, y: v.y * s };
+}
+
+export function clamp(v: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, v));
+}

--- a/typescript/bouncing-boubles/src/game/ball.ts
+++ b/typescript/bouncing-boubles/src/game/ball.ts
@@ -1,0 +1,26 @@
+import { Vec2 } from "../core/math";
+
+export class Ball {
+  pos: Vec2;
+  vel: Vec2;
+  radius: number;
+
+  constructor(pos: Vec2, vel: Vec2, radius = 4) {
+    this.pos = { ...pos };
+    this.vel = { ...vel };
+    this.radius = radius;
+  }
+
+  update(dt: number) {
+    // dt in ms, convert to seconds for velocity
+    const sec = dt / 1000;
+    this.pos.x += this.vel.x * sec;
+    this.pos.y += this.vel.y * sec;
+  }
+
+  render(ctx: CanvasRenderingContext2D) {
+    ctx.beginPath();
+    ctx.arc(this.pos.x, this.pos.y, this.radius, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}

--- a/typescript/bouncing-boubles/src/game/brick.ts
+++ b/typescript/bouncing-boubles/src/game/brick.ts
@@ -1,0 +1,23 @@
+import { Vec2 } from "../core/math";
+
+export type BrickType = "normal" | "indestructible" | "powerup";
+
+export class Brick {
+  pos: Vec2;
+  width: number;
+  height: number;
+  type: BrickType;
+  hits: number;
+
+  constructor(pos: Vec2, width: number, height: number, type: BrickType = "normal", hits = 1) {
+    this.pos = pos;
+    this.width = width;
+    this.height = height;
+    this.type = type;
+    this.hits = hits;
+  }
+
+  render(ctx: CanvasRenderingContext2D) {
+    ctx.fillRect(this.pos.x, this.pos.y, this.width, this.height);
+  }
+}

--- a/typescript/bouncing-boubles/src/game/level.ts
+++ b/typescript/bouncing-boubles/src/game/level.ts
@@ -1,0 +1,16 @@
+import { Brick, BrickType } from "./brick";
+
+export type LevelDefinition = (BrickType | 0)[][];
+
+export function createLevel(def: LevelDefinition, brickWidth = 32, brickHeight = 16): Brick[] {
+  const bricks: Brick[] = [];
+  for (let y = 0; y < def.length; y++) {
+    for (let x = 0; x < def[y].length; x++) {
+      const type = def[y][x];
+      if (type) {
+        bricks.push(new Brick({ x: x * brickWidth, y: y * brickHeight }, brickWidth, brickHeight, type));
+      }
+    }
+  }
+  return bricks;
+}

--- a/typescript/bouncing-boubles/src/game/paddle.ts
+++ b/typescript/bouncing-boubles/src/game/paddle.ts
@@ -1,0 +1,36 @@
+import { Vec2 } from "../core/math";
+import { Input } from "../core/input";
+
+export class Paddle {
+  pos: Vec2;
+  width: number;
+  height: number;
+  speed: number;
+  private bounds: { w: number; h: number };
+
+  constructor(private canvas: HTMLCanvasElement, private input: Input) {
+    this.width = 60;
+    this.height = 10;
+    this.speed = 300; // pixels per second
+    this.pos = { x: canvas.width / 2, y: canvas.height - 30 };
+    this.bounds = { w: canvas.width, h: canvas.height };
+  }
+
+  update(dt: number) {
+    const sec = dt / 1000;
+    if (this.input.left) this.pos.x -= this.speed * sec;
+    if (this.input.right) this.pos.x += this.speed * sec;
+    // mouse steering
+    if (!this.input.left && !this.input.right) {
+      this.pos.x = this.input.mouseX;
+    }
+    // clamp
+    const half = this.width / 2;
+    if (this.pos.x - half < 0) this.pos.x = half;
+    if (this.pos.x + half > this.bounds.w) this.pos.x = this.bounds.w - half;
+  }
+
+  render(ctx: CanvasRenderingContext2D) {
+    ctx.fillRect(this.pos.x - this.width / 2, this.pos.y - this.height / 2, this.width, this.height);
+  }
+}

--- a/typescript/bouncing-boubles/src/game/state.ts
+++ b/typescript/bouncing-boubles/src/game/state.ts
@@ -1,0 +1,15 @@
+export enum GameState {
+  Title,
+  Playing,
+  Paused,
+  LevelClear,
+  GameOver,
+}
+
+export class StateMachine {
+  state: GameState = GameState.Title;
+
+  change(newState: GameState) {
+    this.state = newState;
+  }
+}

--- a/typescript/bouncing-boubles/src/main.ts
+++ b/typescript/bouncing-boubles/src/main.ts
@@ -1,0 +1,33 @@
+import { createLoop } from './core/loop';
+import { Input } from './core/input';
+import { Ball } from './game/ball';
+import { Paddle } from './game/paddle';
+import { createRenderer } from './render/canvas';
+
+const canvas = document.getElementById('game') as HTMLCanvasElement;
+const renderer = createRenderer(canvas);
+const input = new Input(canvas);
+const paddle = new Paddle(canvas, input);
+const ball = new Ball({ x: 320, y: 200 }, { x: 120, y: -120 });
+
+function update(dt: number) {
+  paddle.update(dt);
+  ball.update(dt);
+
+  // wall collisions
+  if (ball.pos.x < ball.radius || ball.pos.x > canvas.width - ball.radius) {
+    ball.vel.x *= -1;
+  }
+  if (ball.pos.y < ball.radius || ball.pos.y > canvas.height - ball.radius) {
+    ball.vel.y *= -1;
+  }
+}
+
+function render() {
+  renderer.clear();
+  const ctx = renderer.ctx;
+  paddle.render(ctx);
+  ball.render(ctx);
+}
+
+createLoop(update, render);

--- a/typescript/bouncing-boubles/src/render/canvas.ts
+++ b/typescript/bouncing-boubles/src/render/canvas.ts
@@ -1,0 +1,11 @@
+export function createRenderer(canvas: HTMLCanvasElement) {
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Cannot get 2D context');
+  ctx.imageSmoothingEnabled = false;
+  return {
+    ctx,
+    clear() {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+    },
+  };
+}

--- a/typescript/bouncing-boubles/tsconfig.json
+++ b/typescript/bouncing-boubles/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "es6",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "noImplicitAny": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold browser-based Bouncing Boubles project in TypeScript
- implement core loop, input handling, math utilities, and basic ball/paddle gameplay
- include simple renderer and entry point wired to an HTML canvas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5738b2bb88327b45378bd2d9f7eec